### PR TITLE
Reimplemented compile_against_conda.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,16 @@ this repository into the directory of your choosing.  The package cmake
 can still be used but the environment variables must be set to point to
 the dependencies and libraries stored in PREFIX/CHOOSE_ENV_NAME.  NeuroProof
 includes a simple wrapper script 'compile_against_conda.sh' that simply
-calls cmake with the correct environment variables.  To build NeuroProof:
+calls the conda recipe build script with the appropriate environment variables.
+To build it:
 
-    % mkdir build; cd build
-    % export CONDA_ENV_PATH=PREFIX/CHOOSE_ENV_NAME
-    % ../compile_against_conda.sh
-    % make -j NUM_PROCESSORS
-    % make install
+    % ./compile_against_conda.sh /path/to/flyem-build-conda /path/to/your/environment-prefix
 
-Calling make install will over-write the binaries and libraries in your CHOOSE_ENV_NAME.
-Currently, LD_LIBRARY_PATH needs to be set to PREFIX/CHOOSE_ENV_NAME/lib to use
-libraries installed this way.
+That will over-write the binaries and libraries in the environment path you gave.
+(If necessary, it will install gcc first.)
+To use your custom build of NeuroProof, you'll need to set the `LD_LIBRARY_PATH` environment variable:
+
+    % export LD_LIBRARY_PATH=/path/to/your/environment-prefix/lib
 
 For coding that requires adding new dependencies please consult documentation for
 building conda builds and consult Fly EM's conda recipes.

--- a/compile_against_conda.sh
+++ b/compile_against_conda.sh
@@ -1,53 +1,34 @@
-# Must specify the path to the conda environment (CONDA_ENV_PATH)
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <install-environment-dir>"
+    exit 1;
+fi
 
-# Depending on our platform, shared libraries end with either .so or .dylib
-if [[ `uname` == 'Darwin' ]]; then
-    DYLIB_EXT=dylib
+# Start in the same directory as this script.
+cd `dirname $0`
+
+export PREFIX="$1"
+export PYTHON="${PREFIX}/bin/python"
+export CPU_COUNT=`python -c "import multiprocessing; print multiprocessing.cpu_count()"`
+export PATH="${PREFIX}/bin":$PATH
+
+# Install gcc first if necessary.
+if [ ! -e "${PREFIX}/bin/gcc" ]; then
+    conda install -p "${PREFIX}" -c flyem gcc
+fi
+
+# Do you already have curl?
+curl --help > /dev/null
+if [[ $? == 0 ]]; then
+    CURL=curl
 else
-    DYLIB_EXT=so
+    # Install to conda prefix
+    conda install -p "${PREFIX}" curl
+    CURL="${PREFIX}/bin/curl"
 fi
 
-# This variable can be used to (indirectly) read/set the contents of either 
-# LD_LIBRARY_PATH or DYLD_LIBRARY_PATH, depending on your platform.
-# To set as a prefix of a command (e.g. before 'make check'), use eval:
-#  eval $LIBRARY_SEARCH_VAR=/path/to/lib;/another/path/to/lib make check
-# To read (using modern bash indirection syntax):
-#  echo ${!LIBRARY_SEACH_VAR}
-if [[ `uname` == 'Darwin' ]]; then
-    LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-else
-    LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-fi
+# Run the build script from the recipe.
+# (It uses $PREFIX and $PYTHON and $CPU_COUNT)
+bash "${FLYEM_RECIPES_DIR}/neuroproof/build.sh"
 
-# Typically, conda erases LD_LIBRARY_PATH before building the recipe,
-# but some recipes can specifically override this behavior via the build:script_env setting in meta.yaml.
-# It can be useful to allow this, but it is very dangerous.
-# We give a warning about it here.
-if [[ -n ${!LIBRARY_SEARCH_VAR} ]]; then
-    echo "*** WARNING: You are using a non-empty value of ${LIBRARY_SEARCH_VAR}:"
-    echo "*** ${LIBARY_SEARCH_VAR}=${!LIBRARY_SEARCH_VAR}"
-    echo "*** This can make your build difficult to reproduce.  Make sure you know what you're doing."
-fi
-
-#
-# We OVERRIDE conda's default value for MACOSX_DEPLOYMENT_TARGET, 
-#  because we want to link against libc++ (not stdlibc++) for C++ libraries (like vigra)
-#
-export MACOSX_DEPLOYMENT_TARGET=10.7
-
-PYTHON=${CONDA_ENV_PATH}/bin/python
-
-
-cmake ..\
-        -DCMAKE_C_COMPILER=${CONDA_ENV_PATH}/bin/gcc \
-        -DCMAKE_CXX_COMPILER=${CONDA_ENV_PATH}/bin/g++ \
-        -DCMAKE_INSTALL_PREFIX=${CONDA_ENV_PATH} \
-        -DCMAKE_PREFIX_PATH=${CONDA_ENV_PATH} \
-        -DCMAKE_CXX_FLAGS=-I${CONDA_ENV_PATH}/include \
-        -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,${CONDA_ENV_PATH}/lib -L${CONDA_ENV_PATH}/lib" \
-        -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,${CONDA_ENV_PATH}/lib -L${CONDA_ENV_PATH}/lib" \
-        -DENABLE_GUI=1 \
-        -DBoost_INCLUDE_DIR=${CONDA_ENV_PATH}/include \
-        -DPYTHON_EXECUTABLE=${PYTHON} \
-        -DPYTHON_LIBRARY=${CONDA_ENV_PATH}/lib/libpython2.7.${DYLIB_EXT} \
-        -DPYTHON_INCLUDE_DIR=${CONDA_ENV_PATH}/include/python2.7 \
+BUILD_SCRIPT_URL=https://raw.githubusercontent.com/janelia-flyem/flyem-build-conda/master/neuroproof/build.sh
+"$CURL" "$BUILD_SCRIPT_URL" | bash


### PR DESCRIPTION
compile_against_conda.sh:
- First, the script installs `gcc` if necessary.
- Call the neuroproof recipe build script instead of reimplementing it.
- Can be called from any directory (not just `build`)
- New usage is as follows:
  
  ```
  % ./compile_against_conda.sh /path/to/your/environment-prefix
  ```

PS -- Requires the latest rev of `flyem-build-conda`, because I had to make a [tiny change](https://github.com/janelia-flyem/flyem-build-conda/commit/8cf4eadc693d511de5121e550e95127f7e05afcd) to it for this to work.
