### PR TITLE
VigraRFclassifier: Open H5 file in read-only mode.

### DIFF
--- a/src/Classifier/vigraRFclassifier.cpp
+++ b/src/Classifier/vigraRFclassifier.cpp
@@ -10,7 +10,7 @@ VigraRFclassifier::VigraRFclassifier(const char* rf_filename){
 }
 
 void  VigraRFclassifier::load_classifier(const char* rf_filename){
-     	HDF5File rf_file(rf_filename,HDF5File::Open); 	
+     	HDF5File rf_file(rf_filename,HDF5File::OpenReadOnly);
 	if(!_rf)
 		_rf = new RandomForest<>;
      	rf_import_HDF5(*_rf, rf_file,"rf");


### PR DESCRIPTION
This fixes the problem we saw the other day when running NeuroProof segmentation with a read-only classifier file.
